### PR TITLE
Feature/65

### DIFF
--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/EV3/Balancer.cs
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/EV3/Balancer.cs
@@ -27,7 +27,7 @@ namespace ETRobocon.EV3
 		const float A_R = 0.996F;
 
 		///	servo control state feedback gain for NXT standard tire
-		static float[] K_F = new float[4] {-0.870303F, -31.9978F, -1.1566F * 0.6F, -2.78873F};
+		static float[] K_F = new float[4] {-0.84000F, -40.87459F, -0.90567F, -4.23856F};
 
 		/// servo control integral gain
 		const float K_I = -0.44721F;
@@ -36,7 +36,7 @@ namespace ETRobocon.EV3
 		const float K_PHIDOT = 25.0F * 2.5F;
 
 		/// forward target speed gain
-		const float K_THETADOT = 7.5F;
+		const float K_THETADOT = 14.7F;
 
 		/// battery voltage gain for motor PWM outputs
 		const float BATTERY_GAIN = 0.001089F;


### PR DESCRIPTION
# 目的
- バランスパラメータを確定させること
# やった事
## 概要
- `Balancer`の`K_F[]`と`K_THETADOT`をよりよい値に修正しました。
## 詳細
- 導出方法は[こちら](../wiki/バランスパラメータの決定%28実践編%29)を参照のこと。
# やってない事
- パラメータをいじる以外の修正はしてません。
# 確認してほしい事
## ソースコード

Balancerのパラメータが[こちら](../wiki/バランスパラメータの決定%28実践編%29)の10.5cmアレンジのパラメータとなっていること。
## 動作確認
- 必要
1. きちんと立つこと MUST
2. 前の実装より機敏に動くようになっていること WANT
# 確認した事
- きちんと立つこと
- 前の実装より機敏に動くようになっていること
# 確認結果

確認をおこなったら、下表にOK/NGを記載する事
コメントがある場合は、Issueにコメントを追加する事

※レビュイーは事前の動作確認は済ませておくこと.

| 実装 | アカウント | ソース | 動作確認1 | 動作確認2 | 確認項目以外 |
| --- | --- | --- | --- | --- | --- |
| Yes | @naoki-tomita | --- | OK | OK | --- |
|  | @masjinno |  |  |  |  |
|  | @Geroshabu | OK | OK | OK | OK |
|  | @masanori1102 | OK |  |  | OK |
|  | @fu-min |  |  |  |  |
|  | @mizutayo |  |  |  |  |
