### PR TITLE
レビュー指摘(#139, #159)への対応

### DIFF
--- a/src/common/CommandFormat.cs
+++ b/src/common/CommandFormat.cs
@@ -76,6 +76,37 @@ namespace ETRobocon.Utils
 			return parsedCommand;
 		}
 
+		/// <summary>文字列を指定した型に変換(処理部分)</summary>
+		/// <returns>
+		/// 型変換したものをボックス化した<c>object</c>.
+		/// 型変換に失敗した場合は<c>null</c>.
+		/// </returns>
+		/// <param name="str">変換する文字列</param>
+		/// <param name="type">変換先の型</param>
+		private static object ParseStringWithType_Processor(string str, Type type)
+		{
+			if ((str == null) || (type == null))
+			{
+				return null;
+			}
+
+			if (type.Equals(typeof(bool)))	{	return	(object)Convert.ToBoolean(str);	}
+			if (type.Equals(typeof(sbyte)))	{	return	(object)Convert.ToSByte(str);	}
+			if (type.Equals(typeof(short)))	{	return	(object)Convert.ToInt16(str);	}
+			if (type.Equals(typeof(int)))	{	return	(object)Convert.ToInt32(str);	}
+			if (type.Equals(typeof(long)))	{	return	(object)Convert.ToInt64(str);	}
+			if (type.Equals(typeof(byte)))	{	return	(object)Convert.ToByte(str);	}
+			if (type.Equals(typeof(ushort)))	{	return	(object)Convert.ToUInt16(str);	}
+			if (type.Equals(typeof(uint)))	{	return	(object)Convert.ToUInt32(str);	}
+			if (type.Equals(typeof(ulong)))	{	return	(object)Convert.ToUInt64(str);	}
+			if (type.Equals(typeof(decimal)))	{	return	(object)Convert.ToDecimal(str);	}
+			if (type.Equals(typeof(char)))	{	return	(object)Convert.ToChar(str);	}
+			if (type.Equals(typeof(float)))	{	return	(object)Convert.ToSingle(str);	}
+			if (type.Equals(typeof(double)))	{	return	(object)Convert.ToDouble(str);	}
+			if (type.Equals(typeof(string)))	{	return	(object)str;	}
+			return null;
+		}
+
 		/// <summary>文字列を指定した型に変換</summary>
 		/// <returns>
 		/// 型変換したものをボックス化した<c>object</c>.
@@ -85,27 +116,9 @@ namespace ETRobocon.Utils
 		/// <param name="type">変換先の型</param>
 		private static object ParseStringWithType(string str, Type type)
 		{
-			if (str == null || type == null)
+			try
 			{
-				return null;
-			}
-
-			try {
-				if (type.Equals (typeof(bool))) { return (object)Convert.ToBoolean(str); }
-				else if (type.Equals (typeof(sbyte))) {	return (object)Convert.ToSByte(str); }
-				else if (type.Equals (typeof(short))) { return (object)Convert.ToInt16(str); }
-				else if (type.Equals (typeof(int))) { return (object)Convert.ToInt32(str); }
-				else if (type.Equals (typeof(long))) { return (object)Convert.ToInt64(str); }
-				else if (type.Equals (typeof(byte))) { return (object)Convert.ToByte(str); }
-				else if (type.Equals (typeof(ushort))) { return (object)Convert.ToUInt16(str); }
-				else if (type.Equals (typeof(uint))) { return (object)Convert.ToUInt32(str); }
-				else if (type.Equals (typeof(ulong))) { return (object)Convert.ToUInt64(str); }
-				else if (type.Equals (typeof(decimal))) { return (object)Convert.ToDecimal(str); }
-				else if (type.Equals (typeof(char))) { return (object)Convert.ToChar(str); }
-				else if (type.Equals (typeof(float))) { return (object)Convert.ToSingle(str); }
-				else if (type.Equals (typeof(double))) { return (object)Convert.ToDouble(str); }
-				else if (type.Equals (typeof(string))) { return (object)str; }
-				else { return null; }
+				return	ParseStringWithType_Processor(str, type);
 			}
 			catch (FormatException)
 			{


### PR DESCRIPTION
# 目的

複雑度を下げ、メンテナンスコストを低減させる
# やった事

[private static object ParseStringWithType(string str, Type type)](../pull/160/files#diff-7b625894de7ab14f4e292e6e33c83c88R117)のtry節の中を[private static object ParseStringWithType_Processor(string str, Type type)](../pull/160/files#diff-7b625894de7ab14f4e292e6e33c83c88R86)に抽出する事で、以下のレビュー指摘2点に対応した。
1. 指摘(#137) : else if節をif節に変更する事(#139)
2. 指摘(#137) : 条件分岐を関数化する事(#159)
## 変更による効果

2つの関数で責務を分担する事によって、想定しなければいけない条件が69から22に下がった。
### 変更前

「try節の中の、15ある条件分岐それぞれが、正しく行われるか例外を創出するかを気にする」必要があった。
#### 条件の内訳
- str == null
- type == null
- try節の条件分岐13個に対して
  - 正常終了
  - 関数に記載されている例外3つ
  - 関数に記載されていない例外1つ
- try節の条件分岐2個に対して
  - 正常終了
### 変更後
- [private static object ParseStringWithType(string str, Type type)](../pull/160/files#diff-7b625894de7ab14f4e292e6e33c83c88R117) : 「try節で、例外を創出するかどうか」だけを気にすれば良くなった。
- [private static object ParseStringWithType_Processor(string str, Type type)](../pull/160/files#diff-7b625894de7ab14f4e292e6e33c83c88R86) : 「どの条件分岐が成り立つか」だけを気にすれば良くなった。
#### 条件の内訳
- [private static object ParseStringWithType(string str, Type type)](../pull/160/files#diff-7b625894de7ab14f4e292e6e33c83c88R117)
  - try節が
    - 正常終了
    - 関数に記載されている例外3つ
    - 関数に記載されていない例外1つ
- [private static object ParseStringWithType_Processor(string str, Type type)](../pull/160/files#diff-7b625894de7ab14f4e292e6e33c83c88R86)
  - 条件分岐17個
# 確認してほしい事
## ソースコード
- ビルド
- 変更内容
## 動作確認

今回は動作に関する変更ではなく、動作も #137 で確認している為、不要。
# 確認した事

ビルドできる事を確認した
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。

| 実装 | アカウント | ソースコード | それ以外 |
| --- | --- | --- | --- |
|  | @masjinno |  |  |
|  | @Geroshabu | OK |  |
|  | @naoki-tomita |  |  |
| Yes | @masanori1102 | - | - |
|  | @fu-min |  |  |
|  | @mizutayo |  |  |
# 終了条件
- 1人以上のソースコードの確認
- MUST対応の指摘が無い事
