### PR TITLE
"指摘(#137) : ソースコードとコメントを一致させる事"への対応

### DIFF
--- a/src/common/CommandFormat.cs
+++ b/src/common/CommandFormat.cs
@@ -38,6 +38,7 @@ namespace ETRobocon.Utils
 			Command parsedCommand = new Command(CommandID.Invalid, null, null);
 
 			// パラメータが3個以上あるのは不正
+			// (最初の要素にはコマンド名が入っているので, argvの要素数 = パラメータ数 + 1)
 			if (argv.Length > 3)
 			{
 				return parsedCommand;


### PR DESCRIPTION
# 目的

ソースコードに対して誤ったコメントがされていた部分の修正確認.(#138)
# やった事

[CommandFormat.cs の 40行目](https://github.com/RITS-ETrobo/Yokohama/pull/161/files#diff-7b625894de7ab14f4e292e6e33c83c88R40) のコメントの修正.
# 確認してほしい事
## ソースコード
- ビルド
- 変更内容
## 動作確認

コメントの修正なので不要.
# 確認した事

ビルドできる事
# 確認結果

確認をおこなったら, 下表にOKもしくはissue番号を記載する事.

| 実装 | アカウント | ソースコード | それ以外 |
| --- | --- | --- | --- |
|  | @masjinno |  |  |
| Yes | @Geroshabu | - | - |
|  | @naoki-tomita |  |  |
|  | @masanori1102 | OK |  |
|  | @fu-min |  |  |
|  | @mizutayo |  |  |
# 終了条件
- 1人以上のソースコードの確認
- MUST対応の指摘が無い事
