### PR TITLE
"指摘(#137) : 量を表す値は、コメントに単位を記載する事" への対応

### DIFF
--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Utils/CommandTask.cs
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Utils/CommandTask.cs
@@ -15,10 +15,10 @@ namespace ETRobocon.Utils
 		/// <summary>コマンドタスクが実行されているスレッド</summary>
 		private Thread _CommandThread;
 
-		/// <summary>コマンドタスクのメインループのSleep時間</summary>
+		/// <summary>コマンドタスクのメインループのSleep時間[ms]</summary>
 		private const int LOOP_INTERVAL = 16;
 
-		/// <summary>コマンドパラメータがEV3側に到着するのが遅れたときの待ち時間</summary>
+		/// <summary>コマンドパラメータがEV3側に到着するのが遅れたときの待ち時間[ms]</summary>
 		private const int RECEIVE_INTERVAL = 4;
 
 		/// <summary>この回数だけパラメータの受信を試みる</summary>


### PR DESCRIPTION
# 目的

時間を表す定数のコメントに, 単位を表すコメントが付加されていることの確認.(#142)
# やった事

EV3側[CommandTask.cs](https://github.com/RITS-ETrobo/Yokohama/blob/feature/142/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Utils/CommandTask.cs#L18) の次の定数のコメントの修正.
- `private const int LOOP_INTERVAL = 16;`
- `private const int RECEIVE_INTERVAL = 4;`
# 確認してほしい事
## ソースコード
- ビルド
- 変更内容
## 動作確認

コメントの修正なので不要.
# 確認した事

ビルドできる事
# 確認結果

確認をおこなったら, 下表にOKもしくはissue番号を記載する事.

| 実装 | アカウント | ソースコード | それ以外 |
| --- | --- | --- | --- |
|  | @masjinno |  |  |
| Yes | @Geroshabu | - | - |
|  | @naoki-tomita |  |  |
|  | @masanori1102 | OK |  |
|  | @fu-min |  |  |
|  | @mizutayo |  |  |
# 終了条件
- 1人以上のソースコードの確認
- MUST対応の指摘が無い事
