### PR TITLE
"指摘(#132) : 量を表す値は、コメントに単位を記載する事"への対応

### DIFF
--- a/src/EV3Way_MonoBrick_RemoteConsole/EV3Way_MonoBrick_RemoteConsole/Utils/LogTask.cs
+++ b/src/EV3Way_MonoBrick_RemoteConsole/EV3Way_MonoBrick_RemoteConsole/Utils/LogTask.cs
@@ -13,7 +13,7 @@ namespace EV3Way_MonoBrick_RemoteConsole.Utils
 		/// <summary>ログタスクが実行されているスレッド</summary>
 		private Thread _logThread;
 
-		/// <summary>ログタスクのメインループのSleep時間</summary>
+		/// <summary>ログタスクのメインループのSleep時間[ms]</summary>
 		private const int LOOP_INTERVAL = 16;
 
 		/// <summary>ログとして受信できないデータが送られてきたときの代替文字列</summary>

--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Utils/LogTask.cs
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Utils/LogTask.cs
@@ -23,7 +23,7 @@ namespace ETRobocon.Utils
 		/// <summary>ログタスクが実行されているスレッド</summary>
 		private Thread _logThread;
 
-		/// <summary>ログタスクのメインループのSleep時間</summary>
+		/// <summary>ログタスクのメインループのSleep時間[ms]</summary>
 		private const int LOOP_INTERVAL = 16;
 
 		/// <summary>ログを溜めておくQueue</summary>


### PR DESCRIPTION
# 目的

時間を表す定数のコメントに, 単位を表すコメントが付加されていることの確認.(#217)
# やった事

EV3側[LogTask.cs](https://github.com/RITS-ETrobo/Yokohama/blob/feature/217/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Utils/LogTask.cs#L27) の次の定数のコメントの修正.
- `private const int LOOP_INTERVAL = 16;`

PC側[LogTask.cs](https://github.com/RITS-ETrobo/Yokohama/blob/feature/217/src/EV3Way_MonoBrick_RemoteConsole/EV3Way_MonoBrick_RemoteConsole/Utils/LogTask.cs#L17) の次の定数のコメントの修正.
- `private const int LOOP_INTERVAL = 16;`
# 確認してほしい事
## ソースコード
- ビルド
- 変更内容
## 動作確認

コメントの修正なので不要.
# 確認した事

ビルドできる事
# 確認結果

確認をおこなったら, 下表にOKもしくはissue番号を記載する事.

| 実装 | アカウント | ソースコード | それ以外 |
| --- | --- | --- | --- |
|  | @masjinno |  |  |
| Yes | @Geroshabu | - | - |
|  | @naoki-tomita |  |  |
|  | @masanori1102 | OK |  |
|  | @fu-min |  |  |
|  | @mizutayo |  |  |
# 終了条件
- 1人以上のソースコードの確認
- MUST対応の指摘が無い事
