### PR TITLE
#194 ジャイロセンサーの位置を逆にする

### DIFF
--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Main.cs
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Main.cs
@@ -169,7 +169,7 @@ namespace ETRobocon.EV3
 					turn = (body.color.Read () >= (LIGHT_BLACK + LIGHT_WHITE) / 2) ? (sbyte)50 : (sbyte)-50;
 				}
 
-				int gyroNow = -body.gyro.Read();
+				int gyroNow = body.gyro.Read();
 				int thetaL = body.motorL.GetTachoCount();
 				int theTaR = body.motorR.GetTachoCount();
 				sbyte pwmL, pwmR;


### PR DESCRIPTION
# 目的
#194

ジャイロセンサーの位置が逆になったことにより、ロボットが前後を逆に認識するようになってしまった。
コードで、前後を逆に認識するよう、修正する。
# やった事
## 概要

ジャイロセンサー値を取得するところで、これまでは符号を反転させていたのに対し、符号を反転させないよう処理を修正した。
## 詳細

ソースコードをご確認ください。
# やってない事

実機での動作確認(ただし、#195 で修正したものを動作させて、問題ないことを確認しました。)
# 確認してほしい事
## ソースコード
- ジャイロセンサー値を取得しているところで、`-`の符号を削除した。
## 動作確認
- ジャイロセンサーの位置を変更したロボットで、走ることを確認する。
# 確認した事
- 別のプログラムで、`-`を外すことで動作することを確認済み。
  - このコードでは、まだ試していません。
