### PR TITLE
Feature/235 targetAngleの値の検証をプロパティで行う

### DIFF
--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Motor/MotorTail.cs
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Motor/MotorTail.cs
@@ -54,7 +54,7 @@ namespace ETRobocon.EV3
 				return _totalSteps;
 			}
 			set{
-				_totalSteps = value;
+				_totalSteps = (value < 1) ? 1 : value;
 			}
 		}
 
@@ -114,9 +114,6 @@ namespace ETRobocon.EV3
 		{
 			startAngle = motorTail.GetTachoCount ();
 			targetAngle = angle;
-			if (steps < 1) {
-				steps = 1;
-			}
 			totalSteps = steps;
 			currentStep = 1;
 			subTargetAnglePerStep = (float)(targetAngle - startAngle) / totalSteps;


### PR DESCRIPTION
#235 2つのメンバをプロパティ化しました
# 目的

値の検証をプロパティ内部で行うこと
# やった事
## 概要

下記2メンバのプロパティ化
- targetAngle
- totalSteps
## 詳細

特になし
# やってない事

特になし
# 確認してほしい事
## ソースコード
- 妥当なプロパティ化が実現できていること
## 動作確認
#81 で動作確認を行うため、このプルリクエストでは不要とのことでした。
### ~~事前修正~~
- ~~K_THETADOTを12.9に変更~~
- ~~乾電池パラメータに変更~~
### ~~確認項目~~
- ~~乾電池でこけずに走行すること~~
# 確認した事
- 乾電池での走行確認
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。

| 実装 | アカウント | ソースコード | 動作 | それ以外 |
| --- | --- | --- | --- | --- |
| Yes | @masjinno | - | - | - |
|  | @Geroshabu | OK | - |  |
|  | @naoki-tomita |  | - |  |
|  | @masanori1102 |  | - |  |
|  | @fu-min |  | - |  |
|  | @mizutayo |  | - |  |
# 終了条件
- 1人以上のソースコードの確認
- ~~1人以上の動作の確認~~
- MUST対応の指摘が無い事
