### PR TITLE
feature/237 冗長なメソッドの一本化

### DIFF
--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Motor/MotorTail.cs
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Motor/MotorTail.cs
@@ -92,25 +92,11 @@ namespace ETRobocon.EV3
 		}
 
 		/// <summary>
-		/// 尻尾モーターの角度を設定する.
-		/// </summary>
-		/// <param name="angle">設定したい角度</param>
-		public void SetMotorAngleImmediately(int angle)
-		{
-			startAngle = motorTail.GetTachoCount ();
-			targetAngle = angle;
-			totalSteps = 1;
-			currentStep = 1;
-			subTargetAnglePerStep = targetAngle - startAngle;
-			subTargetAngle = targetAngle;
-		}
-
-		/// <summary>
 		/// 尻尾モーターの角度を指定した段階数を踏んで設定する.
 		/// </summary>
 		/// <param name="angle">設定したい角度</param>
 		/// <param name="steps">段階数. 値が大きいほどゆっくり設定する</param>
-		public void SetMotorAngleSlowly(int angle, int steps)
+		public void SetMotorAngle(int angle, int steps=1)
 		{
 			startAngle = motorTail.GetTachoCount ();
 			targetAngle = angle;

--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/StateMachine/States/ReadyState.cs
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/StateMachine/States/ReadyState.cs
@@ -42,7 +42,7 @@ namespace ETRobocon.StateMachine
 
 			LogTask.LogRemote("EV3 is ready.");
 
-			_body.motorTail.SetMotorAngleImmediately (MotorTail.TAIL_ANGLE_STAND_UP);	//完全停止用角度に制御
+			_body.motorTail.SetMotorAngle (MotorTail.TAIL_ANGLE_STAND_UP);	//完全停止用角度に制御
 		}
 
 		public override void Do()
@@ -52,7 +52,7 @@ namespace ETRobocon.StateMachine
 
 		public override void Exit()
 		{
-			_body.motorTail.SetMotorAngleImmediately (MotorTail.TAIL_ANGLE_STAND_UP);	//完全停止用角度に制御
+			_body.motorTail.SetMotorAngle (MotorTail.TAIL_ANGLE_STAND_UP);	//完全停止用角度に制御
 
 			// スイッチが離されるのを待つ
 			// TODO: "押されたときだけを検出する"ような機能をタッチセンサーに持たせ, ここの処理は削除する.

--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/StateMachine/States/StraightWithLineTraceState.cs
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/StateMachine/States/StraightWithLineTraceState.cs
@@ -26,7 +26,7 @@ namespace ETRobocon.StateMachine
 			// 電圧を取得
 			_batteryLevel = Brick.GetVoltageMilliVolt();
 
-			_body.motorTail.SetMotorAngleImmediately (MotorTail.TAIL_ANGLE_DRIVE);	//バランス走行用角度に制御
+			_body.motorTail.SetMotorAngle (MotorTail.TAIL_ANGLE_DRIVE);	//バランス走行用角度に制御
 		}
 
 		public override void Do()


### PR DESCRIPTION
#237 冗長だった2つのメソッドを1つにしました。
# 目的

冗長な記述をなくすことで、可読性を高めること
# やった事
## 概要
- SetMotorAngleImmediatelyメソッドと、SetMotorAngleSlowlyメソッドの廃止
- SetMotorAngleメソッドの作成
## 詳細
- SetMotorAngleメソッドの引数が1つであれば、SetMotorAngleImmediatelyメソッドと同じ処理を、<br>
  SetMotorAngleメソッドの引数が2つであれば、SetMotorAngleSlowlyメソッドと同じ処理をします。
# やってない事

動作確認
# 確認してほしい事
## ソースコード
- 記述が妥当であること
## 動作確認
#81 で行う。
# 確認した事

なし
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。

| 実装 | アカウント | ソースコード | ~~動作~~ | それ以外 |
| --- | --- | --- | --- | --- |
| Yes | @masjinno | - | - | - |
|  | @Geroshabu | OK | - |  |
|  | @naoki-tomita |  | - |  |
|  | @masanori1102 | OK | - |  |
|  | @fu-min |  | - |  |
|  | @mizutayo |  | - |  |
# 終了条件
- 1人以上のソースコードの確認
- ~~1人以上の動作の確認~~
- MUST対応の指摘が無い事
