### PR TITLE
Feature/268 指摘(#267) : 下限値を別に定義する事

### DIFF
--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Body/GyroSensor.cs
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Body/GyroSensor.cs
@@ -11,7 +11,7 @@ namespace ETRobocon.Body
 		/// <summary>センサーの値を保持する</summary>
 		private bool rapidChange;
 
-		/// <summary>正常値の上限(-1倍すれば下限)</summary>
+		/// <summary>正常と判断するジャイロセンサー値の大きさの上限</summary>
 		private const int BORDER_RAPID_CHANGE = 180;
 
 		public GyroSensor (SensorPort inport, GyroMode velocity )
@@ -26,7 +26,10 @@ namespace ETRobocon.Body
 			int sensorValue;
 			sensorValue = gyroSensor.Read ();
 
-			// 値が異常値を示したら, 急激な変化があったと判断する.
+			// ジャイロセンサー値が異常値を示したら, 急激な変化があったと判断する.
+			// ジャイロセンサー値が正：前方に回転する加速
+			// ジャイロセンサー値が負：後方に回転する加速
+			// 前方への加速の大きさと後方への加速の大きさは同一である.
 			if (sensorValue < -BORDER_RAPID_CHANGE || sensorValue > BORDER_RAPID_CHANGE) {
 				rapidChange = true;
 			}


### PR DESCRIPTION
# 関連Issue
#268
# 目的

BORDER_RAPID_CHANGE定数の役割がコメントから読み取れるように記述すること
# やった事

BORDER_RAPID_CHANGE定数に関する処理において、コメントを修正した.
# 確認してほしい事
## ソースコード
#268 における指摘に沿って修正されていること
## 動作確認
#267 で行う.
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。

| 実装 | アカウント | ソースコード | 動作 | それ以外 |
| --- | --- | --- | --- | --- |
| Yes | @masjinno | - | - | - |
|  | @Geroshabu |  | - |  |
|  | @naoki-tomita |  | - |  |
|  | @masanori1102 | OK | - |  |
|  | @fu-min |  | - |  |
|  | @mizutayo |  | - |  |
# 終了条件
- 1人以上のソースコードの確認
- MUST対応の指摘が無い事
