### PR TITLE
Feature/269 指摘(#267) : センサーを保持する/しない条件を明記する事

### DIFF
--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Body/GyroSensor.cs
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/Body/GyroSensor.cs
@@ -8,7 +8,10 @@ namespace ETRobocon.Body
 	{
 		EV3GyroSensor gyroSensor;
 
-		/// <summary>センサーの値を保持する</summary>
+		/// <summary>
+		/// GetSensorValueメソッドで衝撃を検知したかどうかを保持する.
+		/// true:衝撃を検知した.  false:衝撃を検知していない.
+		/// </summary>
 		private bool rapidChange;
 
 		/// <summary>正常値の上限(-1倍すれば下限)</summary>


### PR DESCRIPTION
# 関連Issue
#269
# 目的
- rapidChangeメンバ宣言時のコメントが、メンバの役割と一致させること
- 一度rapidChangeが衝撃検知したときの値になっていても、衝撃を検知していないときの値に書き換えられるような実装になっていること
# やった事
## 概要
- rapidChangeメンバ宣言時のコメントの修正
- GetSensorValueメソッドで、「取得したジャイロセンサー値が正常ならば衝撃を検知していない」処理の追加
## 詳細

省略
# やってない事

特になし
# 確認してほしい事
## ソースコード

目的を満たす修正がされていること
## 動作確認

処理に関係する変更がありますが、静的な確認のみでもよろしいでしょうか？
- 非常に簡潔な修正であるため
- 修正が活きるシーンに入るためのソースコード変更量が非常に膨大であるため
  - 衝撃を検知 → 停止を確認 → 再度走行可能な状態を作る → 走行確認
# 確認した事

特になし
(修正内容は事前に確認済み)

| 実装 | アカウント | ソースコード | 動作 | それ以外 |
| --- | --- | --- | --- | --- |
| Yes | @masjinno | - | - | - |
|  | @Geroshabu |  | - |  |
|  | @naoki-tomita |  | - |  |
|  | @masanori1102 | OK | - |  |
|  | @fu-min |  | - |  |
|  | @mizutayo |  | - |  |
# 終了条件
- 1人以上のソースコードの確認
- MUST対応の指摘が無い事
