### PR TITLE
Feature/300 else ifではなく、ifに変更する

### DIFF
--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/StateMachine/States/StartState.cs
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/StateMachine/States/StartState.cs
@@ -84,7 +84,7 @@ namespace ETRobocon.StateMachine
 			if (counter <= 0) {	// 既定のループ数に到達.
 				return TriggerID.TimeExpire;
 			}
-			else if (CommandReceiveFlags.Instance.CheckCommandReceived(CommandID.Stop))
+			if (CommandReceiveFlags.Instance.CheckCommandReceived(CommandID.Stop))
 			{
 				return TriggerID.StopCommand;
 			}


### PR DESCRIPTION
# 関連Issue
#300
# やった事

StartStateクラスのJudgeTransitionメソッドにおいて、else ifの不要なelseを削除した。
# 確認してほしい事
## ソースコード
- 不要な else if の else が、削除されているか
- 必要な else if の else が、削除されていないこと　(←もともとメソッド内には存在しないはず。)
## 動作確認
#298 で実施します。
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。

| 実装 | アカウント | ソースコード | 動作 | それ以外 |
| --- | --- | --- | --- | --- |
| Yes | @masjinno | - | - | - |
|  | @Geroshabu |  | - |  |
|  | @naoki-tomita |  | - |  |
|  | @masanori1102 | OK | - |  |
|  | @fu-min |  | - |  |
|  | @mizutayo |  | - |  |
# 終了条件
- 1人以上のソースコードの確認
- MUST対応の指摘が無い事
