### PR TITLE
Feature/310 ビルドオプションを充電池からRelease_RechargeableBatteryに変更した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 x86
 obj
 Debug
+Release_RechargeableBattery
 *.pdb
 *.mdb
 

--- a/src/EV3Way_MonoBrick_RemoteConsole/EV3Way_MonoBrick_RemoteConsole/EV3Way_MonoBrick_RemoteConsole.csproj
+++ b/src/EV3Way_MonoBrick_RemoteConsole/EV3Way_MonoBrick_RemoteConsole/EV3Way_MonoBrick_RemoteConsole.csproj
@@ -20,11 +20,6 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
     <Externalconsole>true</Externalconsole>
-    <CustomCommands>
-      <CustomCommands>
-        <Command type="AfterBuild" />
-      </CustomCommands>
-    </CustomCommands>
     <DocumentationFile>..\..\..\bin\Debug\EV3Way_MonoBrick_RemoteConsole.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
@@ -35,6 +30,11 @@
     <PlatformTarget>x86</PlatformTarget>
     <Externalconsole>true</Externalconsole>
     <DocumentationFile>..\..\..\bin\Release\EV3Way_MonoBrick_RemoteConsole.xml</DocumentationFile>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="AfterBuild" command="xcopy /y /i &quot;${TargetFile}&quot; &quot;${TargetDir}\..\Release_RechargeableBattery&quot;" workingdir="" externalConsole="True" />
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/EV3way_MonoBrick_Remote/AOTCompileApp/AOTCompileApp.csproj
+++ b/src/EV3way_MonoBrick_Remote/AOTCompileApp/AOTCompileApp.csproj
@@ -31,11 +31,13 @@
     <ConsolePause>false</ConsolePause>
     <DocumentationFile>..\..\..\bin\Release\AOTCompileApp.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == '充電池|x86' ">
-    <Optimize>false</Optimize>
-    <OutputPath>bin\x86\充電池</OutputPath>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release_RechargeableBattery|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\bin\Release_RechargeableBattery</OutputPath>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
+    <ConsolePause>false</ConsolePause>
+    <DocumentationFile>..\..\..\bin\Release_RechargeableBattery\AOTCompileApp.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/EV3way_MonoBrick_Remote/EV3way_MonoBrick.sln
+++ b/src/EV3way_MonoBrick_Remote/EV3way_MonoBrick.sln
@@ -9,21 +9,21 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
 		Release|x86 = Release|x86
-		充電池|x86 = 充電池|x86
+		Release_RechargeableBattery|x86 = Release_RechargeableBattery|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D143CFF0-F2F5-474A-B631-698EC2E98A12}.Debug|x86.ActiveCfg = Debug|x86
 		{D143CFF0-F2F5-474A-B631-698EC2E98A12}.Debug|x86.Build.0 = Debug|x86
 		{D143CFF0-F2F5-474A-B631-698EC2E98A12}.Release|x86.ActiveCfg = Release|x86
 		{D143CFF0-F2F5-474A-B631-698EC2E98A12}.Release|x86.Build.0 = Release|x86
-		{D143CFF0-F2F5-474A-B631-698EC2E98A12}.充電池|x86.ActiveCfg = 充電池|x86
-		{D143CFF0-F2F5-474A-B631-698EC2E98A12}.充電池|x86.Build.0 = 充電池|x86
+		{D143CFF0-F2F5-474A-B631-698EC2E98A12}.Release_RechargeableBattery|x86.ActiveCfg = Release_RechargeableBattery|x86
+		{D143CFF0-F2F5-474A-B631-698EC2E98A12}.Release_RechargeableBattery|x86.Build.0 = Release_RechargeableBattery|x86
 		{FCEE4FA1-741D-41EA-A24A-804F2BC2A6D4}.Debug|x86.ActiveCfg = Debug|x86
 		{FCEE4FA1-741D-41EA-A24A-804F2BC2A6D4}.Debug|x86.Build.0 = Debug|x86
 		{FCEE4FA1-741D-41EA-A24A-804F2BC2A6D4}.Release|x86.ActiveCfg = Release|x86
 		{FCEE4FA1-741D-41EA-A24A-804F2BC2A6D4}.Release|x86.Build.0 = Release|x86
-		{FCEE4FA1-741D-41EA-A24A-804F2BC2A6D4}.充電池|x86.ActiveCfg = 充電池|x86
-		{FCEE4FA1-741D-41EA-A24A-804F2BC2A6D4}.充電池|x86.Build.0 = 充電池|x86
+		{FCEE4FA1-741D-41EA-A24A-804F2BC2A6D4}.Release_RechargeableBattery|x86.ActiveCfg = Release_RechargeableBattery|x86
+		{FCEE4FA1-741D-41EA-A24A-804F2BC2A6D4}.Release_RechargeableBattery|x86.Build.0 = Release_RechargeableBattery|x86
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/src/EV3way_MonoBrick_Remote/ev3way_monobrick/ev3way_monobrick.csproj
+++ b/src/EV3way_MonoBrick_Remote/ev3way_monobrick/ev3way_monobrick.csproj
@@ -32,14 +32,14 @@
     <DocumentationFile>..\..\..\bin\Release\EV3Way.xml</DocumentationFile>
     <AssemblyName>EV3Way</AssemblyName>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == '充電池|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release_RechargeableBattery|x86' ">
     <Optimize>true</Optimize>
-    <OutputPath>bin\x86\充電池</OutputPath>
+    <OutputPath>..\..\..\bin\Release_RechargeableBattery</OutputPath>
     <WarningLevel>4</WarningLevel>
     <AssemblyName>ev3way_monobrick</AssemblyName>
     <PlatformTarget>x86</PlatformTarget>
     <DefineConstants>RechargeableBattery</DefineConstants>
-    <DocumentationFile>bin\x86\充電池\EV3Way.xml</DocumentationFile>
+    <DocumentationFile>..\..\..\bin\Release_RechargeableBattery\EV3Way.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
# 関連Issue
#310

# 目的
1. ビルドオプションから日本語を取り除きたい
1. ビルドオプションによっては、bin以外にもファイルを残す事があるのを、bin以下だけに集約したい
1. 充電池用のビルドをおこなっただけでは、必要なファイルが1つのディレクトリに集まらないので、1つのディレクトリに集めたい

# やった事
1. ビルドオプションを充電池から、Release_RechargeableBatteryに変更した
1. 全てのビルドオプションで、bin以下にファイルを出力するように変更した 
1. EV3Way_MonoBrick_RemoteConsoleをReleaseビルドして、bin\Release_RechargeableBatteryに成果物がコピーする設定に変更した

# 確認してほしい事
## ソースコード
1. ビルドオプションが充電池ではなく、Release_RechargeableBatteryになっている事
1. 全てのビルドオプションで、出力結果がbin以下である事 
1. EV3Way_MonoBrick_RemoteConsoleをReleaseビルドして、bin\Release_RechargeableBatteryに成果物がコピーされる事

## 動作確認
なし

# 確認した事
上記の「確認してほしい事\ソースコード」と同じことを確認した.

# 確認結果
確認をおこなったら、下表にOKもしくはissue番号を記載する事。

|実装|アカウント|ソースコード|それ以外|
|-----|------------|---------|-----------|
| |@masjinno| | |
| |@Geroshabu| | |
| |@naoki-tomita| | |
| Yes |@masanori1102| - | - |
| |@fu-min| | |
| |@mizutayo| | |

# 終了条件
* 1人以上のソースコードの確認
* MUST対応の指摘が無い事