### PR TITLE
[レビュー]#421 : make結果をファイルに保存する

### DIFF
--- a/scripts/make_project.sh
+++ b/scripts/make_project.sh
@@ -7,10 +7,11 @@ if [ $# -ne 2 ]; then
 fi
 
 TARGET_PROJECT=$1
-make $2=${TARGET_PROJECT}
+make $2=${TARGET_PROJECT} 1>build.log 2>&1
 TARGET_PATH=bin/$2/$1
 rm -rf ${TARGET_PATH}
 mkdir -p ${TARGET_PATH}
+mv build.log ${TARGET_PATH}/${TARGET_PROJECT}.$2.log
 mv app ${TARGET_PATH}/${TARGET_PROJECT}.$2
 mv OBJ/ ${TARGET_PATH}
 


### PR DESCRIPTION
# 関連Issue
#421
# 目的

ビルド結果をふりかえる事ができるようにする
# 実績
## やった事
### 概要

makeコマンドの後に、`1>build.log 2>&1`を付けた
変更前

``` shell
#!/bin/bash
...
command
```

変更後

``` shell
#!/bin/bash
...
command 1>build.log 2>&1
```
### 確認した事

makeコマンドの結果が、`hrp2/workspace/bin/{app | mod}/{ディレクトリ}/{ディレクトリ}.{app | mod}.log`に出力される事
## やってない事
- プロダクトコードの変更
- makeコマンドの変更
# 確認してほしい事
## ソースコード
1. [[Bash]標準出力・標準エラー出力の全て（1>&2とか）まとめ | Coffee Breakにプログラミング備忘録](http://to-developer.com/blog/?p=1001)と同様の変更をおこなっている事
2. makeコマンドを実行した時に、`hrp2/workspace/bin/{app | mod}/{ディレクトリ}/{ディレクトリ}.{app | mod}.log`に出力される事
### 動作確認

不要

---
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。
実装した人は、[実装]列に Yes と記載し、[ソースコード]と[それ以外] に - を入れる事

| 実装 | アカウント | ソースコード | それ以外 |
| --- | --- | --- | --- |
| Yes | @masanori1102 | - | - |
|  | @masjinno |  |  |
|  | @masaYajima |  |  |
|  | @takase-etrobo |  |  |
# 終了条件

なし
