### PR TITLE
[レビュー]#512 ：makeの対象からlinetraceを除く

### DIFF
--- a/scripts/make_all.sh
+++ b/scripts/make_all.sh
@@ -22,7 +22,6 @@ ${SCRIPT_PATH} gyroboy ${buildOption}
 ${SCRIPT_PATH} helloev3 ${buildOption}
 ${SCRIPT_PATH} hackEV ${buildOption}
 ${SCRIPT_PATH} hwbrickbench ${buildOption}
-${SCRIPT_PATH} linetrace ${buildOption}
 ${SCRIPT_PATH} sample_c4 ${buildOption}
 ${SCRIPT_PATH} test-cpp ${buildOption}
 ${SCRIPT_PATH} test-cyc ${buildOption}


### PR DESCRIPTION
# 関連Issue

 #512 
# 目的

linetraceをmake対象から除くことによって、サポート範囲を限定する。
# 実績
## やった事
### 概要

`/scripts/make_all.sh`から`${SCRIPT_PATH} linetrace ${buildOption}`を削除した
### 確認した事

・プロジェクトのルートmakeした結果(下記参照)、
`hrp2/sdk/bin/app/linetrace` と`hrp2/sdk/bin/img/linetrace`が生成されないことを確認した。

↓make方法

``` bash
./scripts/create_env.sh
rm -rf hrp2/sdk/bin
./scripts/make_all.sh app
./scripts/make_all.sh img
```
### 考慮した事
#### [リスク](https://kotobank.jp/word/%E3%83%AA%E3%82%B9%E3%82%AF-183705)

なし
#### [懸念事項](https://kotobank.jp/word/%E6%87%B8%E5%BF%B5-490895)

なし
# 確認してほしい事
## ソースコード

変更点の確認と、以下をプロジェクトルートから実行する事

``` bash
./scripts/create_env.sh
rm -rf hrp2/sdk/bin
./scripts/make_all.sh app
./scripts/make_all.sh img
```
### 動作確認

不要

---
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。
実装した人は、[実装]列に Yes と記載し、[ソースコード]と[それ以外] に - を入れる事

| 実装 | アカウント | ソースコード | それ以外 |
| --- | --- | --- | --- |
|  | @masanori1102 | OK | OK |
|  | @masjinno |  |  |
| Yes | @masaYajima | - | - |
|  | @takase-etrobo |  |  |
# 終了条件

以下が確認できた時に、本Pull requestをマージし、終了する。
- Merge先がReleaseブランチである事
- 1人以上がソースコードを確認し、問題ない事
- 期待通りの動作である事
- MUST対応の指摘が無い事
