### PR TITLE
[レビュー]#608 : TOPPERS_MACRO_ONLYが有効だったら、makeを失敗させる

### DIFF
--- a/hrp2/sdk/workspace/hackEV/RunningModule.h
+++ b/hrp2/sdk/workspace/hackEV/RunningModule.h
@@ -8,8 +8,6 @@
 #include "target_test.h"
 
 //  関数のプロトタイプ宣言
-#ifndef TOPPERS_MACRO_ONLY
-    extern void	initialize_run();
-    extern void start_run(int power,int corveAngle);
-    extern void run_withPID();
-#endif /* TOPPERS_MACRO_ONLY */
+extern void	initialize_run();
+extern void start_run(int power,int corveAngle);
+extern void run_withPID();

--- a/hrp2/sdk/workspace/hackEV/SonarSensorController.h
+++ b/hrp2/sdk/workspace/hackEV/SonarSensorController.h
@@ -1,6 +1,6 @@
 /**
- * @file    UltrasonicController.h
- * @brief   This file has UltrasonicController
+ * @file    SonarSensorController.h
+ * @brief   This file has SonarSensorController
  */
 #pragma once
 
@@ -19,10 +19,8 @@ extern const sensor_port_t sonar_sensor;
 //@}
 
 //  関数のプロトタイプ宣言
-#ifndef TOPPERS_MACRO_ONLY
-    extern void	initialize_sonarsensor();
-    extern void control_sonarsensor();
-#endif /* TOPPERS_MACRO_ONLY */
+extern void	initialize_sonarsensor();
+extern void control_sonarsensor();
 
 extern void setEnabledSonarSensor(bool _enabledSonarSensor);
 

--- a/hrp2/sdk/workspace/hackEV/app.h
+++ b/hrp2/sdk/workspace/hackEV/app.h
@@ -48,6 +48,10 @@ extern "C" {
 //! ターゲット依存の定義
 #include "target_test.h"
 
+#ifdef TOPPERS_MACRO_ONLY
+    #error TOPPERS_MACRO_ONLY is defined.
+#endif  //  TOPPERS_MACRO_ONLY
+
 //! \addtogroup 各タスクの優先度の定義
 //@{
 //! メインタスクの優先度 : HIGH_PRIORITYより高くすること
@@ -73,31 +77,29 @@ extern "C" {
 #endif /* LOOP_REF */
 
 //  関数のプロトタイプ宣言
-#ifndef TOPPERS_MACRO_ONLY
-    extern void	task(intptr_t exinf);
-    extern void	main_task(intptr_t exinf);
-    extern void balance_task(intptr_t exinf);
-    extern void idle_task(intptr_t exinf);
-    extern void stop_emergency();
-    //extern void	tex_routine(TEXPTN texptn, intptr_t exinf);
-    //#ifdef CPUEXC1
-    //  extern void	cpuexc_handler(void *p_excinf);
-    //#endif /* CPUEXC1 */
-    //extern void	cyclic_handler(intptr_t exinf);
-    //extern void	alarm_handler(intptr_t exinf);
-    //
-    //extern void	gpio_handler_initialize(intptr_t exinf);
-    //extern void	gpio_handler(void);
-    extern void	gpio_irq_dispatcher(intptr_t exinf);
-    //
-    //extern void	uart_sensor_monitor(intptr_t exinf);
-    //
-    //extern void	ev3_uart_cyclic_handler(intptr_t exinf);
-    //extern void	ev3_uart_daemon(intptr_t exinf);
-    //extern void	ev3_uart_port2_irq(void);
-    //
-    //extern void initialize_ev3(intptr_t exinf);
-#endif /* TOPPERS_MACRO_ONLY */
+extern void	task(intptr_t exinf);
+extern void	main_task(intptr_t exinf);
+extern void balance_task(intptr_t exinf);
+extern void idle_task(intptr_t exinf);
+extern void stop_emergency();
+//extern void	tex_routine(TEXPTN texptn, intptr_t exinf);
+//#ifdef CPUEXC1
+//  extern void	cpuexc_handler(void *p_excinf);
+//#endif /* CPUEXC1 */
+//extern void	cyclic_handler(intptr_t exinf);
+//extern void	alarm_handler(intptr_t exinf);
+//
+//extern void	gpio_handler_initialize(intptr_t exinf);
+//extern void	gpio_handler(void);
+extern void	gpio_irq_dispatcher(intptr_t exinf);
+//
+//extern void	uart_sensor_monitor(intptr_t exinf);
+//
+//extern void	ev3_uart_cyclic_handler(intptr_t exinf);
+//extern void	ev3_uart_daemon(intptr_t exinf);
+//extern void	ev3_uart_port2_irq(void);
+//
+//extern void initialize_ev3(intptr_t exinf);
 
 #ifdef __cplusplus
 }

--- a/hrp2/sdk/workspace/hackEV/gyroboy.h
+++ b/hrp2/sdk/workspace/hackEV/gyroboy.h
@@ -13,11 +13,9 @@ extern "C" {
 #include "target_test.h"
 
 //  関数のプロトタイプ宣言
-#ifndef TOPPERS_MACRO_ONLY
-    extern void balance_task(intptr_t exinf);
-    extern void idle_task(intptr_t exinf);
-    extern void drive_controller_task(intptr_t exinf);
-#endif  //  TOPPERS_MACRO_ONLY
+extern void balance_task(intptr_t exinf);
+extern void idle_task(intptr_t exinf);
+extern void drive_controller_task(intptr_t exinf);
 
 #ifdef __cplusplus
 }

--- a/hrp2/sdk/workspace/hackEV/pid_controller.h
+++ b/hrp2/sdk/workspace/hackEV/pid_controller.h
@@ -13,10 +13,8 @@ extern "C" {
 #include "target_test.h"
 
 //  関数のプロトタイプ宣言
-#ifndef TOPPERS_MACRO_ONLY
-    extern void initialize_pid_controller();
-    extern void pid_controller_task(intptr_t exinf);
-#endif /* TOPPERS_MACRO_ONLY */
+extern void initialize_pid_controller();
+extern void pid_controller_task(intptr_t exinf);
 
 #ifdef __cplusplus
 }

--- a/hrp2/sdk/workspace/hackEV/utilities.h
+++ b/hrp2/sdk/workspace/hackEV/utilities.h
@@ -40,11 +40,9 @@ extern const motor_port_t right_motor;
 //@}
 
 //  関数のプロトタイプ宣言
-#ifndef TOPPERS_MACRO_ONLY
-    extern void configure_motors();
-    extern void configure_sensors();
-    extern int calibrate_light_intensity();
-#endif  //  TOPPERS_MACRO_ONLY
+extern void configure_motors();
+extern void configure_sensors();
+extern int calibrate_light_intensity();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# 関連Issue
#608
# 目的

実行不可能な状態でmakeを成功させない
# 実績
## やった事
### 概要

関数の宣言を「`TOPPERS_MACRO_ONLY`が無効な時」という条件で囲むのを止めた
### 確認した事

makeが成功する事
### 考慮した事
#### [リスク](https://kotobank.jp/word/%E3%83%AA%E3%82%B9%E3%82%AF-183705)

なし
#### [懸念事項](https://kotobank.jp/word/%E6%87%B8%E5%BF%B5-490895)

なし
## やってない事

走行プログラムの変更
# 確認してほしい事
## ソースコード

変更内容
### 確認内容

該当する項目にチェックを付ける事
- [x] 走行体のプログラムを変えた : 動作確認必要
  - [ ] タスクを増やした
  - [ ] 生成のタイミングを変更した
- [x] プロジェクトのルートで、`./scripts/createEnv_and_makeAll.sh`を実行して、エラーが無い
#### 動作確認が必要な場合に記載する

基本的な動作の確認

---
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。
実装した人は、[実装]列に Yes と記載し、[ソースコード]と[それ以外] に - を入れる事

| 実装 | アカウント | ソースコード | それ以外 |
| --- | --- | --- | --- |
| Yes | @masanori1102 | - | - |
|  | @masjinno |  |  |
|  | @masaYajima |  |  |
|  | @takase-etrobo |  |  |
# 終了条件

以下が確認できた時に、本Pull requestをマージし、終了する。
- Merge先が`hackev/cpp/develop`ブランチである事
- 1人以上がソースコードを確認し、問題ない事
- 期待通りの動作である事
- MUST対応の指摘が無い事
