### PR TITLE
[レビュー]#622 : LCDの再描画を修正する

### DIFF
--- a/hrp2/sdk/workspace/hackEV/LCDController.cpp
+++ b/hrp2/sdk/workspace/hackEV/LCDController.cpp
@@ -80,9 +80,13 @@ ER writeStringLCD(const char* message)
 {
     unsigned int lineHeight = getLineheight();
     if (currentAreaHeight + lineHeight > EV3_LCD_HEIGHT) {
-        ev3_lcd_fill_rect(0, 0, EV3_LCD_WIDTH, lineHeight, getLCDColor());
+        //! 次のページに書く場合は、先に前ページの残りを塗りつぶす
+        ev3_lcd_fill_rect(0, currentAreaHeight, EV3_LCD_WIDTH, EV3_LCD_HEIGHT - currentAreaHeight, getLCDColor());
         currentAreaHeight = 0;
     }
+
+    //! これから書く領域を塗りつぶす
+    ev3_lcd_fill_rect(0, currentAreaHeight, EV3_LCD_WIDTH, lineHeight, getLCDColor());
 
     ER  result = ev3_lcd_draw_string(message, 0, currentAreaHeight);
     if (result == E_OK) {


### PR DESCRIPTION
# 関連Issue : Must
#622
# 目的 : Must

LCDに文字列を描画しても、前回の描画結果を残さない
# 実績
## やった事
### 概要 : Must

LCDに描画する前に、描画領域をあらかじめ塗りつぶす処理を追加した
### 確認した事 : Must

makeが成功する事
### 考慮した事
#### [リスク](https://kotobank.jp/word/%E3%83%AA%E3%82%B9%E3%82%AF-183705)

なし
#### [懸念事項](https://kotobank.jp/word/%E6%87%B8%E5%BF%B5-490895)

なし
# 確認してほしい事
## ソースコード : Must

pidテスト走行を実施して、右端に前回の描画結果が残らない事
### 確認内容

該当する項目にチェックを付ける事
- [x] 走行体のプログラムを変えた : 動作確認必要
  - [ ] タスクを増やした
  - [ ] 生成のタイミングを変更した
- [x] プロジェクトのルートで、`./scripts/createEnv_and_makeAll.sh`を実行して、エラーが無い
#### 動作確認が必要な場合に記載する

確認してほしい事参照

---
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。
実装した人は、[実装]列に Yes と記載し、[ソースコード]と[それ以外] に - を入れる事

| 実装 | アカウント | ソースコード | それ以外 |
| --- | --- | --- | --- |
| Yes | @masanori1102 | - | - |
|  | @masjinno |  |  |
|  | @masaYajima |  |  |
|  | @takase-etrobo |  |  |
# 終了条件

以下が確認できた時に、本Pull requestをマージし、終了する。
- Merge先が`hackev/cpp/develop`ブランチである事
- 1人以上がソースコードを確認し、問題ない事
- 期待通りの動作である事
- MUST対応の指摘が無い事
