### PR TITLE
[レビュー]#742 出力時は、ストックしたログを出力用の領域に移動した

### DIFF
--- a/hrp2/sdk/workspace/hackEV/Logger.cpp
+++ b/hrp2/sdk/workspace/hackEV/Logger.cpp
@@ -2,6 +2,7 @@
  * @file    Logger.cpp
  * @brief   This file has Logger class.
   */
+#include <utility>
 #include "Logger.h"
 
 /**
@@ -58,7 +59,8 @@ void Logger::outputLog()
         return;
     }
 
-    for (vector<USER_LOG>::iterator it = loggerInfo.begin(); it != loggerInfo.end(); it ++ ) {
+    vector<USER_LOG> loggerOutput = move(loggerInfo);
+    for (vector<USER_LOG>::iterator it = loggerOutput.begin(); it != loggerOutput.end(); it ++ ) {
         char    logLine[64];
         sprintf(logLine, "%d, %s, %s\r\n", it->logTime, getLogName(it->logType), it->log);
         if (fputs(logLine, fpLog) == EOF) {
@@ -66,6 +68,5 @@ void Logger::outputLog()
         }
     }
 
-    loggerInfo.clear();
     fclose(fpLog);
 }


### PR DESCRIPTION
# 関連Issue : Must

close #742 
# 目的 : Must

ストックしたログが多くなり過ぎて異常終了するのを防ぐ
# 実績
## やった事
### 概要 : Must

ログをファイルに出力する時は、ストックしたログを出力用の領域に移す
### 確認した事 : Must

make成功
### 考慮した事
#### [リスク](https://kotobank.jp/word/%E3%83%AA%E3%82%B9%E3%82%AF-183705)

なし
#### [懸念事項](https://kotobank.jp/word/%E6%87%B8%E5%BF%B5-490895)

なし
# 確認してほしい事
## ソースコード : Must
### 確認内容

該当する項目にチェックを付ける事
- [ ] 走行体のプログラムを変えた : 動作確認必要
  - [ ] タスクを増やした
  - [ ] 生成のタイミングを変更した
- [x] プロジェクトのルートで、`./scripts/createEnv_and_makeAll.sh`を実行して、エラーが無い

---
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。
実装した人は、[実装]列に Yes と記載し、[ソースコード]と[それ以外] に - を入れる事

| 実装 | アカウント | ソースコード | それ以外 |
| --- | --- | --- | --- |
| Yes | @masanori1102 | - | - |
|  | @masjinno |  |  |
|  | @masaYajima |  |  |
|  | @takase-etrobo |  |  |
# 終了条件

以下が確認できた時に、本Pull requestをマージし、終了する。
- Merge先が`hackev/cpp/develop`ブランチである事
- 1人以上がソースコードを確認し、問題ない事
- 期待通りの動作である事
- MUST対応の指摘が無い事
