### PR TITLE
[レビュー]#756 ログ出力にかかった時間をログに出力

### DIFF
--- a/hrp2/sdk/workspace/hackEV/Logger.cpp
+++ b/hrp2/sdk/workspace/hackEV/Logger.cpp
@@ -95,6 +95,11 @@ void Logger::outputLog(bool doClosingLog /*= false*/)
             return;
         }
 
+        SYSTIM  start = 0;
+        if (clock) {
+            start = clock->now();
+        }
+
         vector<USER_LOG> loggerOutput = move(loggerInfo);
         for (vector<USER_LOG>::iterator it = loggerOutput.begin(); it != loggerOutput.end(); it ++ ) {
             if (!outputHeader) {
@@ -108,9 +113,17 @@ void Logger::outputLog(bool doClosingLog /*= false*/)
                 break;
             }
         }
+
+        if (clock) {
+            char message[16];
+            memset(message, '\0', sizeof(message));
+            sprintf(message, "%d", clock->now() - start); 
+            addLog(LOG_TYPE_WRITE_PROCESSING, message);
+        }
     }
 
     if (doClosingLog) {
+        outputLog();
         closeLog();
     }
 }

--- a/hrp2/sdk/workspace/hackEV/params/logSettings.cpp
+++ b/hrp2/sdk/workspace/hackEV/params/logSettings.cpp
@@ -42,6 +42,9 @@ const uint_t LOG_TYPE_DIRECTION_TOTAL = 0x86;
 
 //! ジャイロ
 const uint_t LOG_TYPE_GYRO = 0x87;
+
+//! ログを書き出している時間
+const uint_t LOG_TYPE_WRITE_PROCESSING = 0x88;
 //@}
 
 std::map<uint_t, char*> LOG_TYPE_MAP;
@@ -69,6 +72,7 @@ void initialize_logSetting()
     LOG_TYPE_MAP[LOG_TYPE_DIRECTION] = "Direction";
     LOG_TYPE_MAP[LOG_TYPE_DIRECTION_TOTAL] = "Direction(Total)";
     LOG_TYPE_MAP[LOG_TYPE_GYRO] = "Gyro";
+    LOG_TYPE_MAP[LOG_TYPE_WRITE_PROCESSING] = "Writing Log";
 }
 
 /**

--- a/hrp2/sdk/workspace/hackEV/params/logSettings.h
+++ b/hrp2/sdk/workspace/hackEV/params/logSettings.h
@@ -44,6 +44,9 @@ extern const uint_t LOG_TYPE_DIRECTION_TOTAL;
 
 //! ジャイロ
 extern const uint_t LOG_TYPE_GYRO;
+
+//! ログを書き出している時間
+extern const uint_t LOG_TYPE_WRITE_PROCESSING;
 //@}
 
 extern void initialize_logSetting();


### PR DESCRIPTION
# 関連Issue : Must

close #756 
# 目的 : Must

1周期(=500ms)以内に終わるログの量かどうかを知り、出力するログの量を調整する
# 実績
## やった事
### 概要 : Must

ログ出力時間をログに出力した
### 確認した事 : Must

ログを出力し、かかった時間を計測した
### 考慮した事
#### [リスク](https://kotobank.jp/word/%E3%83%AA%E3%82%B9%E3%82%AF-183705)

なし
#### [懸念事項](https://kotobank.jp/word/%E6%87%B8%E5%BF%B5-490895)

なし
## やってない事 : 必要なら

(一連の変更が既存機能に影響を与えていない事を特筆する)
# 確認してほしい事
## ソースコード : Must

(やった事の内、ソースコードレベルで何を変更したかを記載する)
### 確認内容

該当する項目にチェックを付ける事
- [x] 走行体のプログラムを変えた : 動作確認必要
  - [ ] タスクを増やした
  - [ ] 生成のタイミングを変更した
- [x] プロジェクトのルートで、`./scripts/createEnv_and_makeAll.sh`を実行して、エラーが無い

---
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。
実装した人は、[実装]列に Yes と記載し、[ソースコード]と[それ以外] に - を入れる事

| 実装 | アカウント | ソースコード | それ以外 |
| --- | --- | --- | --- |
|  | @masanori1102 |  |  |
|  | @masjinno |  |  |
|  | @masaYajima |  |  |
|  | @takase-etrobo |  |  |
# 終了条件

以下が確認できた時に、本Pull requestをマージし、終了する。
- Merge先が`hackev/cpp/develop`ブランチである事
- 1人以上がソースコードを確認し、問題ない事
- 期待通りの動作である事
- MUST対応の指摘が無い事
