### PR TITLE
[レビュー]#830 : ログ用構造体の初期化を追加した

### DIFF
--- a/hrp2/sdk/workspace/hackEV/Logger.cpp
+++ b/hrp2/sdk/workspace/hackEV/Logger.cpp
@@ -56,13 +56,13 @@ bool Logger::isEnabled()
 void Logger::addLog(uint_t logType, const char* message)
 {
     USER_LOG    info;
+    memset(&info, '\0', sizeof(info));
     info.logType = logType;
-    info.logTime = 0;
+    strncpy(info.log, message, BUFFER_SIZE_LOG_MESSAGE - 1);
     if (clock) {
         info.logTime = clock->now();
     }
 
-    strncpy(info.log, message, 7);
     loggerInfo.push_back(info);
 }
 
@@ -76,7 +76,7 @@ void Logger::addLog(uint_t logType, const char* message)
 */
 void Logger::addLogFloat(uint_t logType, const float value)
 {
-    char message[8];
+    char message[BUFFER_SIZE_LOG_MESSAGE];
     memset(message, '\0', sizeof(message));
     sprintf(message, "%.2f", floor(value * 100) / (float)100);
 
@@ -97,7 +97,7 @@ void Logger::addLogFloatFormatted(uint_t logType, const float value, const char 
         return;
     }
 
-    char    message[8];
+    char    message[BUFFER_SIZE_LOG_MESSAGE];
     memset(message, '\0', sizeof(message));
     sprintf(message, format, value);
     addLog(logType, message);
@@ -111,7 +111,7 @@ void Logger::addLogFloatFormatted(uint_t logType, const float value, const char 
 */
 void Logger::addLogInt(uint_t logType, const int value)
 {
-    char message[8];
+    char message[BUFFER_SIZE_LOG_MESSAGE];
     memset(message, '\0', sizeof(message));
     sprintf(message, "%d", value);
 
@@ -132,7 +132,7 @@ void Logger::addLogIntFormatted(uint_t logType, const int value, const char *for
         return;
     }
 
-    char    message[8];
+    char    message[BUFFER_SIZE_LOG_MESSAGE];
     memset(message, '\0', sizeof(message));
     sprintf(message, format, value);
     addLog(logType, message);

--- a/hrp2/sdk/workspace/hackEV/Logger.h
+++ b/hrp2/sdk/workspace/hackEV/Logger.h
@@ -14,6 +14,9 @@
 using namespace std;
 using namespace ev3api;
 
+//! ログに出力する文字列のバッファーサイズ
+#define BUFFER_SIZE_LOG_MESSAGE 8
+
 /*! @struct USER_LOG
     @brief  ログに出力する情報
 */
@@ -25,7 +28,7 @@ typedef struct {
     SYSTIM  logTime;
 
     //! ログに出力する文字列(8Bytes)
-    char    log[8];
+    char    log[BUFFER_SIZE_LOG_MESSAGE];
 } USER_LOG;
 
 //! Class for logging


### PR DESCRIPTION
# 関連Issue : Must

close #830 
# 目的 : Must

7文字の文字列(例. `correct`など)を出力した時に、正しくログに出力されるように修正する
# 実績
## やった事
### 概要 : Must
- ログ用構造体の初期化を追加した
- ログ用構造体の文字列を格納するメンバのサイズを定数で宣言した
### 確認した事 : Must

makeの成功
### 考慮した事
#### [リスク](https://kotobank.jp/word/%E3%83%AA%E3%82%B9%E3%82%AF-183705)

なし
#### [懸念事項](https://kotobank.jp/word/%E6%87%B8%E5%BF%B5-490895)

なし
# 確認してほしい事
## ソースコード : Must

変更内容
### 確認内容

該当する項目にチェックを付ける事
- [ ] 走行体のプログラムを変えた : 動作確認必要
  - [ ] タスクを増やした
  - [ ] 生成のタイミングを変更した
- [x] プロジェクトのルートで、`./scripts/createEnv_and_makeAll.sh`を実行して、エラーが無い
#### 動作確認が必要な場合に記載する

その場回転をおこない、出力されるログが以下の通りである事を確認してください。
- [x] 1. ログに`correct`が文字化けせずに出力されている事
- [x] 2. 1が出力されていた時に、`correct`以降のログが正しく出力されている事

---
# 確認結果

確認をおこなったら、下表にOKもしくはissue番号を記載する事。
実装した人は、[実装]列に Yes と記載し、[ソースコード]と[それ以外] に - を入れる事

| 実装 | アカウント | ソースコード | それ以外 |
| --- | --- | --- | --- |
| Yes | @masanori1102 | - | - |
|  | @masjinno |  |  |
|  | @masaYajima |  |  |
|  | @takase-etrobo |  |  |
# 終了条件

以下が確認できた時に、本Pull requestをマージし、終了する。
- Merge先が`hackev/cpp/develop`ブランチである事
- 1人以上がソースコードを確認し、問題ない事
- 期待通りの動作である事
- MUST対応の指摘が無い事
