### PR TITLE
[レビュー] #868 投げ飛ばし関数を実装

### DIFF
--- a/hrp2/sdk/workspace/hackEV/ArmModule.cpp
+++ b/hrp2/sdk/workspace/hackEV/ArmModule.cpp
@@ -120,3 +120,43 @@ ER initialize_arm_position()
     }
 
 }
+
+/**
+ * @brief   ブロックを投げ飛ばす動きをする。
+ *
+ * @param   beforeSetDown  投げ飛ばし動作前に真下に向けるならばtrue
+ * @param   afterSetOriginalPosition    投げ飛ばし後に元の位置に戻すならばtrue
+ * @return  ev3_motor_rotate() 参照
+ */
+ER move_arm_throw_block(bool beforeSetDown = false, bool afterSetOriginalPosition = false)
+{
+    //! 投げ飛ばすときのアームの目標角度
+    const int ARM_DEGREE_TOP = 88;
+    //! 投げ飛ばすときのアーム速度
+    const int ARM_SPEED_THROW = 100;
+
+    //! 投げ飛ばし前後の動作のアーム速度
+    const int ARM_SPEED_DEFAULT = 30;
+
+    //! 次の動作に移る際の遅延時間[ms]
+    const int DELAY_INTERVAL = 500;
+
+    //! 呼ばれた時点の角度
+    int armAngle = ev3_motor_get_counts(EV3_MOTOR_ARM);
+
+    ER result;
+    if (beforeSetDown) {
+        move_arm(0, ARM_SPEED_DEFAULT, false);
+        tslp_tsk(DELAY_INTERVAL);
+    }
+
+    result = move_arm(ARM_DEGREE_TOP, ARM_SPEED_THROW, false);
+
+    if (afterSetOriginalPosition) {
+        tslp_tsk(DELAY_INTERVAL);
+        move_arm(armAngle, ARM_SPEED_DEFAULT, false);
+    }
+
+    return result;
+}
+

--- a/hrp2/sdk/workspace/hackEV/ArmModule.h
+++ b/hrp2/sdk/workspace/hackEV/ArmModule.h
@@ -12,3 +12,4 @@ extern void initialize_arm();
 extern ER move_arm(int degrees, uint32_t speed_abs, bool_t blocking);
 extern ER stop_arm();
 extern ER initialize_arm_position();
+extern ER move_arm_throw_block(bool beforeSetDown, bool afterSetOriginalPosition);


### PR DESCRIPTION
# 関連Issue : Must

close #868 
# 目的 : Must

アームを素早く持ち上げる関数を実装。
この関数は以下のシーンで使用される。
- ET相撲 : ブロックの押し出し
- 検証運び : 検証を掴む
# 実績
## やった事
### 概要 : Must

アームを素早く持ち上げる関数を実装し、ブロック投げ飛ばし動作を確認した。
### 詳細 : 必要なら

なお、ブロック投げ飛ばしは、初期位置のブロックを土俵外へ投げ飛ばすことはできない。4cmほど押してから投げ飛ばすと土俵外へ安定して押し出せる。
### 確認した事 : Must
- ビルドができること
- ブロックを投げ飛ばせること
## やってない事 : 必要なら
- 懸賞がついた懸賞パーツの持ち上げ
# 確認してほしい事
## ソースコード : Must

「目的」に書いたことを実現可能かの確認
### 確認内容

該当する項目にチェックを付ける事
- [x] 走行体のプログラムを変えた : 動作確認必要
  - [ ] タスクを増やした
  - [ ] 生成のタイミングを変更した
- [x] プロジェクトのルートで、`./scripts/createEnv_and_makeAll.sh`を実行して、エラーが無い
- [ ] UnitTestを実行して、エラーが無い

---
# 確認結果
- 実装した人 : Assignee参照
- ソースコードの確認結果
  - [x] OK
  - [ ] NG : 該当箇所にコメントを入れる事
- それ以外の指摘
  - [ ] あり : 詳細はコメントを追加する事
  - [ ] なし
# 終了条件

以下が確認できた時に、本Pull requestをマージし、終了する。
- Merge先が`hackev/cpp/develop`ブランチである事
- 1人以上がソースコードを確認し、問題ない事
- 期待通りの動作である事
- MUST対応の指摘が無い事
