### PR TITLE
[レビュー]#869 懸賞を安全につかめるかを判定する関数を実装

### DIFF
--- a/hrp2/sdk/workspace/hackEV/sensors/SonarSensorController.cpp
+++ b/hrp2/sdk/workspace/hackEV/sensors/SonarSensorController.cpp
@@ -95,18 +95,16 @@ int16_t SonarSensorController::executeSonar()
  *
  * @return  つかめる距離ならばtrueを返す
  */
-bool SonarSensorController::catchablePrizeSafety()
+bool SonarSensorController::isGrabbableDistance()
 {
     int16_t distance = -1;
 
     if (isEnabled()) {
         distance = executeSonar();
-        if (SAFETY_CATCHABLE_PRIZE_DISTANCE_MIN <= distance && distance <= SAFETY_CATCHABLE_PRIZE_DISTANCE_MAX) {
+        if ((SAFETY_CATCHABLE_PRIZE_DISTANCE_MIN <= distance) &&
+            (distance <= SAFETY_CATCHABLE_PRIZE_DISTANCE_MAX)) {
             return true;
-        } else {
-            return false;
         }
-    } else {
-        return false;
     }
+    return false;
 }

--- a/hrp2/sdk/workspace/hackEV/sensors/SonarSensorController.h
+++ b/hrp2/sdk/workspace/hackEV/sensors/SonarSensorController.h
@@ -16,7 +16,7 @@ public:
     virtual void setEnabled(bool _enabled = true);
     virtual bool isEnabled() { return enabled; };
     virtual int16_t executeSonar();
-    virtual bool catchablePrizeSafety();
+    virtual bool isGrabbableDistance();
 
 #ifndef EV3_UNITTEST
     virtual void confirm(int16_t distance);


### PR DESCRIPTION
# 関連Issue : Must

close #869
# 目的 : Must

懸賞手前に来た時点で位置の誤差があると予想されるので、安全につかめる位置にいるかを判定する関数を実装。
# 実績
## やった事
### 概要 : Must

安全に懸賞をつかめる位置にいるならばtrueを返す関数をSonarSensorControllerクラスに実装。
安全につかめる位置は、ソナーセンサーが3cmを返す場合であることを検証済み。
### 詳細

実装した関数を呼んでtrueが返るならば、安全につかめると判定する。
※見ているものが懸賞であり、コースの道順に沿って懸賞に近づいている前提。
また、この関数がfalseを返す場合でも、懸賞をつかめるポジションにいることはありえる。

ただし、サンプリング間隔が十分に空いていることが必要。(2016/08/19 01:15の全体メールを参照。)
動作確認では、100ms間隔で3cmが返ってくるか検証し、その場合に懸賞をつかめることを確認できた。
### 確認した事 : Must
- 3cmが返ってくる場合に、懸賞をつかめること
  - 奥までまっすぐ差し込まれたとき
  - 手前までまっすぐ差し込まれたとき
  - 奥まで右/左にずれて差し込まれたとき
  - 手前まで右/左にずれて差し込まれたとき
  - 奥まで斜めの角度で差し込まれたとき
  - 手前まで斜めの角度で差し込まれたとき
- 懸賞の揺らぎに対しても確認済み
  - 懸賞が走行体側に傾いている場合
  - 懸賞が走行体とは反対側に傾いている場合
# 確認してほしい事
## ソースコード : Must
- ソナーセンサーが3cmを返した場合に、trueを返す実装になっていること
- ソナーセンサーが3cmを返さない場合に、falseを返す実装になっていること
### 確認内容

該当する項目にチェックを付ける事
- [x] 走行体のプログラムを変えた : 動作確認必要
  - [ ] タスクを増やした
  - [ ] 生成のタイミングを変更した
- [x] プロジェクトのルートで、`./scripts/createEnv_and_makeAll.sh`を実行して、エラーが無い
- [ ] UnitTestを実行して、エラーが無い

---
# 確認結果

指摘がある場合は、コメントを残す事(参照 : [About pull request reviews - User Documentation](https://help.github.com/articles/about-pull-request-reviews/))
# 終了条件

以下が確認できた時に、本Pull requestをマージし、終了する。
- Merge先が`hackev/cpp/develop`ブランチである事
- 1人以上がソースコードを確認し、問題ない事
- 期待通りの動作である事
- MUST対応の指摘が無い事
