### PR TITLE
[レビュー] #842 ET相撲: 星取各色に対応した走行シナリオの定義

### DIFF
--- a/hrp2/sdk/workspace/hackEV/params/scenarioRunning.cpp
+++ b/hrp2/sdk/workspace/hackEV/params/scenarioRunning.cpp
@@ -60,7 +60,7 @@ const scenario_running L_Sumo_scenario[23] = {
     { 20, 10.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、サークルを検知した(本当はカラーセンサーで判定)
     { 20,  7.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //前進(このあとアームで投げ飛ばし)
     {-20, 10.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退
-    { 20,  0.000F,  180, PINWHEEL        , false, 0}, //黄の方へ向く
+    { 20,  0.000F,  190, PINWHEEL        , false, 0}, //黄の方へ向く //本当は180
     { 20, 28.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、サークルを検知した(本当はカラーセンサーで判定) //計算上は24cmだが、調整して28cm
     { 20,  7.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //前進(このあとアームで投げ飛ばし)
     {-20, 10.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退
@@ -78,20 +78,20 @@ const scenario_running L_Sumo_scenario_hoshi_red[19] = {
     { 20,  0.000F,   45, PINWHEEL        , false, 0}, //赤の方へ向きなおす
     { 20,  9.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //さらに近寄り、サークルを検知した(本当はカラーセンサーで前進終了判定)
     { 20,  7.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //前進(このあとアームで投げ飛ばし)
-    {-20, 17.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退
+    {-20, 20.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退 //17から20へ調整
     { 20,  0.000F,   90, PINWHEEL        , false, 0}, //奥の方へ向く
     { 20, 30.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、黒ラインを検知した(本当はカラーセンサーで判定)
     { 20,  0.000F,  -90, PINWHEEL        , false, 0}, //緑の方へ向く
-    { 20, 10.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、サークルを検知した(本当はカラーセンサーで判定)
+    { 20, 13.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、サークルを検知した(本当はカラーセンサーで判定) //10から13へ調整
     { 20,  7.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //前進(このあとアームで投げ飛ばし)
     {-20, 10.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退
-    { 20,  0.000F,  180, PINWHEEL        , false, 0}, //黄の方へ向く
-    { 20, 28.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、サークルを検知した(本当はカラーセンサーで判定) //計算上は24cmだが、調整して28cm
+    { 20,  0.000F,  190, PINWHEEL        , false, 0}, //黄の方へ向く //本当は180でよいが調整して190
+    { 20, 30.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、サークルを検知した(本当はカラーセンサーで判定) //計算上は24cmだが、調整して30cm
     { 20,  7.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //前進(このあとアームで投げ飛ばし)
-    {-20, 10.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退
+    {-20, 13.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退 //計算上は10cmだが、(//17から20へ調整)に合わせて13cmに調整
     { 20,  0.000F, -200, PINWHEEL        , false, 0}, //内側に向く
     { 20, 11.174F,   -1, NOTRACE_STRAIGHT, false, 0}, //中間まで進む
-    { 20,  0.000F,  110, PINWHEEL        , true , 0}  //レールの方を向く (ここで新幹線待ち)
+    { 20,  0.000F,  100, PINWHEEL        , true , 0}  //レールの方を向く (ここで新幹線待ち) //(//本当は180でよいが調整して190)に合わせて100に調整
     //{ 20, 40.0F,   -1, NOTRACE_STRAIGHT, false, 0}  //土俵から降りる
 };
 
@@ -103,20 +103,20 @@ const scenario_running L_Sumo_scenario_hoshi_blue[19] = {
     { 20,  0.000F,  -45, PINWHEEL        , false, 0}, //赤の方へ向きなおす
     { 20,  9.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //さらに近寄り、サークルを検知した(本当はカラーセンサーで前進終了判定)
     { 20,  7.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //前進(このあとアームで投げ飛ばし)
-    {-20, 17.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退
+    {-20, 20.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退 //17から20へ調整
     { 20,  0.000F,  -90, PINWHEEL        , false, 0}, //奥の方へ向く
     { 20, 30.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、黒ラインを検知した(本当はカラーセンサーで判定)
     { 20,  0.000F,   90, PINWHEEL        , false, 0}, //黄の方へ向く
-    { 20, 10.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、サークルを検知した(本当はカラーセンサーで判定)
+    { 20, 13.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、サークルを検知した(本当はカラーセンサーで判定) //10から13へ調整
     { 20,  7.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //前進(このあとアームで投げ飛ばし)
     {-20, 10.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退
-    { 20,  0.000F, -180, PINWHEEL        , false, 0}, //緑の方へ向く
-    { 20, 28.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、サークルを検知した(本当はカラーセンサーで判定) //計算上は24cmだが、調整して28cm
+    { 20,  0.000F, -190, PINWHEEL        , false, 0}, //緑の方へ向く //本当は-180でよいが調整して-190
+    { 20, 30.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //近寄り、サークルを検知した(本当はカラーセンサーで判定) //計算上は24cmだが、調整して30cm
     { 20,  7.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //前進(このあとアームで投げ飛ばし)
-    {-20, 10.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退
+    {-20, 13.000F,   -1, NOTRACE_STRAIGHT, false, 0}, //後退 //計算上は10cmだが、(//17から20へ調整)に合わせて13cmに調整
     { 20,  0.000F,  200, PINWHEEL        , false, 0}, //内側に向く
     { 20, 11.174F,   -1, NOTRACE_STRAIGHT, false, 0}, //中間まで進む
-    { 20,  0.000F, -110, PINWHEEL        , true , 0}  //レールの方を向く (ここで新幹線待ち)
+    { 20,  0.000F, -100, PINWHEEL        , true , 0}  //レールの方を向く (ここで新幹線待ち) //(//本当は-180でよいが調整して-190)に合わせて210に調整
     //{ 20, 40.0F,   -1, NOTRACE_STRAIGHT, false, 0}  //土俵から降りる
 };
 

--- a/hrp2/sdk/workspace/hackEV/params/scenarioRunning.h
+++ b/hrp2/sdk/workspace/hackEV/params/scenarioRunning.h
@@ -46,7 +46,7 @@ extern const scenario_running L_StarUP_Sumo_scenario[];
 extern const scenario_running L_Sumo_scenario[23];
 
 //! Lコース（ET相撲. 赤以外を落とすシナリオ. ）
-extern const scenario_running L_Sumo_scenario_hoshi_red[18];
+extern const scenario_running L_Sumo_scenario_hoshi_red[19];
 
 //! Lコース（ET相撲. 青以外を落とすシナリオ. ）
 extern const scenario_running L_Sumo_scenario_hoshi_blue[19];


### PR DESCRIPTION
# 関連Issue : Must

close #842
# 目的 : Must

星取で読み取った色に対応する、土俵上の走行シナリオを定義すること
# 実績
## やった事
### 概要 : Must

星取の各色に対応した走行シナリオを定義しました。
### 確認した事 : Must

追加した4つの走行シナリオの動作確認。
ただし、開始位置は土俵の中心にカラーセンサーが下向きで向いている状態。

なお、土俵乗り上げ位置調整で、この走行シナリオの始の部分が変更される予定です。
変更後：
1. 初手赤ならば左側、初手青ならば右側にいるように乗り上げる
2. 真後ろを向く
3. 黒を検知するまで前進
4, 赤、青のいずれかの方へ向きなおす
5. 検知したら、押し出し用の前進走行
6. 以後シナリオ通り
# 確認してほしい事
## ソースコード : Must

特になし。
### 確認内容

動作すること。
- [x] 走行体のプログラムを変えた : 動作確認必要
  - [ ] タスクを増やした
  - [ ] 生成のタイミングを変更した
- [x] プロジェクトのルートで、`./scripts/createEnv_and_makeAll.sh`を実行して、エラーが無い
- [ ] UnitTestを実行して、エラーが無い
#### 動作確認が必要な場合に記載する

初期位置は中心の縦ライン上で、カラーセンサーが下向きのときに土俵の中心を向いていること

---
# 確認結果

指摘がある場合は、コメントを残す事(参照 : [About pull request reviews - User Documentation](https://help.github.com/articles/about-pull-request-reviews/))
# 終了条件

以下が確認できた時に、本Pull requestをマージし、終了する。
- Merge先が`hackev/cpp/develop`ブランチである事
- 1人以上がソースコードを確認し、問題ない事
- 期待通りの動作である事
- MUST対応の指摘が無い事
