### PR TITLE
[レビュー]#937 周期タスクをシングルトンに変更した

### DIFF
--- a/hrp2/sdk/workspace/hackEV/app.cpp
+++ b/hrp2/sdk/workspace/hackEV/app.cpp
@@ -281,7 +281,7 @@ void gyro_update_task(intptr_t exinf)
         return;
     }
 
-    inProress_Position = true;
+    inProress_Gyro = true;
 
     gyroSensorController->updateGyroRate();
     logger->addLogInt(LOG_TYPE_GYRO, gyroSensorController->getGyroRate());


### PR DESCRIPTION
# 関連Issue : Must

close #937 
# 目的 : Must

前に実行したタスクが完了してから、次のタスクを始める事によって、未実行のタスクを発生させない
# 実績
## やった事
### 概要 : Must

周期タスクをシングルトンに変更した
### 確認した事 : Must

makeの成功(app)
### 考慮した事
#### [リスク](https://kotobank.jp/word/%E3%83%AA%E3%82%B9%E3%82%AF-183705)

なし
#### [懸念事項](https://kotobank.jp/word/%E6%87%B8%E5%BF%B5-490895)

なし
# 確認してほしい事
## ソースコード : Must

(やった事の内、ソースコードレベルで何を変更したかを記載する)
### 確認内容

該当する項目にチェックを付ける事
- [x] 走行体のプログラムを変えた : 動作確認必要
  - [ ] タスクを増やした
  - [ ] 生成のタイミングを変更した
- [x] プロジェクトのルートで、`./scripts/createEnv_and_makeAll.sh`を実行して、エラーが無い
- [ ] UnitTestを実行して、エラーが無い
#### 動作確認が必要な場合に記載する

(どのような確認をおこなえば良いか(簡単な動作確認(起動、走行など)なのか、変更に特化した確認なのか)を記載する。)

---
# 確認結果

指摘がある場合は、コメントを残す事(参照 : [About pull request reviews - User Documentation](https://help.github.com/articles/about-pull-request-reviews/))
# 終了条件

以下が確認できた時に、本Pull requestをマージし、終了する。
- Merge先が`hackev/cpp/develop`ブランチである事
- 1人以上がソースコードを確認し、問題ない事
- 期待通りの動作である事
- MUST対応の指摘が無い事
