### PR TITLE
[レビュー]#953 走行中は常に色を調べる

### DIFF
--- a/hrp2/sdk/workspace/hackEV/DriveController.cpp
+++ b/hrp2/sdk/workspace/hackEV/DriveController.cpp
@@ -34,6 +34,7 @@ DriveController::DriveController()
     , positionTargetYLast(0.0F)
     , initialized(false)
     , enabled(false)
+    , lastColor(COLOR_NONE)
 {
 }
 
@@ -51,6 +52,9 @@ bool DriveController::initialize()
         directionTotal = 0.0F;
         distanceTotal = 0.0F;
         lastTime = 0;
+        if (colorSensorController) {
+            lastColor = colorSensorController->getColorID();
+        }
     }
 
     //  シナリオごとに初期化する
@@ -1117,6 +1121,17 @@ void DriveController::updatePosition()
     record.distanceDelta = distanceDelta;
     record.directionDelta = directionDelta;
     speedCalculator100ms->add(record);
+
+    if (colorSensorController) {
+        uint8_t currentColor = colorSensorController->getColorID();
+        if (lastColor != currentColor) {
+            lastColor = currentColor;
+            if (logger) {
+                //  前回と色が違った時は、ログに出力する
+                logger->addLogInt(LOG_TYPE_COLOR, currentColor);
+            }
+        }
+    }
 
     if (logger) {
         //ログが多くなり過ぎて、異常終了する為、コメント

--- a/hrp2/sdk/workspace/hackEV/DriveController.h
+++ b/hrp2/sdk/workspace/hackEV/DriveController.h
@@ -121,4 +121,7 @@ private:
 
     //! 利用可能かどうか
     bool    enabled;
+
+    //! 前回の色
+    uint8_t lastColor;
 };

--- a/hrp2/sdk/workspace/hackEV/sensors/ColorSensorController.cpp
+++ b/hrp2/sdk/workspace/hackEV/sensors/ColorSensorController.cpp
@@ -21,7 +21,7 @@ ColorSensorController::ColorSensorController(sensor_port_t _port)
  * 
  * @return  なし
 */
-void ColorSensorController::addColorMap(colorid_t color_id, std::string color_name)
+void ColorSensorController::addColorMap(uint8_t color_id, std::string color_name)
 {
     COLOR_NAME_MAP[color_id] = color_name;
 }
@@ -50,7 +50,7 @@ void ColorSensorController::initialize() {
  * @return  取得したカラーのID
  *          issues/811にて、RED, GREEN, BLUE, YELLOW, BLACK, WHITE のいずれかを返すように変更する。
 */
-colorid_t ColorSensorController::getColorID()
+uint8_t ColorSensorController::getColorID()
 {
     //'HSV色空間'について、wikipediaの項目を参考にした
     rgb_raw_t colorRGB = getColorRGBraw();
@@ -60,11 +60,11 @@ colorid_t ColorSensorController::getColorID()
 
     //白黒判定
     if (BORDER_WHITE_MIN < minimumValue) { //白判定
-        return  COLOR_WHITE;
+        return  (uint8_t)COLOR_WHITE;
     }
 
     if (maximumValue < BORDER_BLACK_MAX) { //黒判定
-        return  COLOR_BLACK;
+        return  (uint8_t)COLOR_BLACK;
     }
 
     //色判定
@@ -78,22 +78,22 @@ colorid_t ColorSensorController::getColorID()
 
     //色相値から色判定
     if (hue < BORDER_RED_YELLOW || BORDER_BLUE_RED <= hue) {
-        return  COLOR_RED;
+        return  (uint8_t)COLOR_RED;
     }
 
     if (hue < BORDER_YELLOW_GREEN) {
-        return  COLOR_YELLOW;
+        return  (uint8_t)COLOR_YELLOW;
     }
 
     if (hue < BORDER_GREEN_BLUE) {
-        return  COLOR_GREEN;
+        return  (uint8_t)COLOR_GREEN;
     }
 
     if (hue < BORDER_BLUE_RED) {
-        return  COLOR_BLUE;
+        return  (uint8_t)COLOR_BLUE;
     }
 
-    return  COLOR_NONE;
+    return  (uint8_t)COLOR_NONE;
 }
 
 /**
@@ -133,7 +133,7 @@ double ColorSensorController::getHue(uint8_t red, uint8_t green, uint8_t blue)
 */
 std::string ColorSensorController::getColorName()
 {
-    colorid_t   color = getColorID();
+    uint8_t color = getColorID();
     return  getColorName(color);
 }
 
@@ -142,7 +142,7 @@ std::string ColorSensorController::getColorName()
  * @param   color_id    色のID
  * @return  取得した色の名前
 */
-std::string ColorSensorController::getColorName(colorid_t color_id)
+std::string ColorSensorController::getColorName(uint8_t color_id)
 {
     return  COLOR_NAME_MAP[color_id];
 }

--- a/hrp2/sdk/workspace/hackEV/sensors/ColorSensorController.h
+++ b/hrp2/sdk/workspace/hackEV/sensors/ColorSensorController.h
@@ -15,18 +15,18 @@ class ColorSensorController
 public:
     explicit ColorSensorController(sensor_port_t _port);
     virtual void initialize();
-    virtual colorid_t getColorID();
+    virtual uint8_t getColorID();
     virtual std::string getColorName();
-    virtual std::string getColorName(colorid_t color);
+    virtual std::string getColorName(uint8_t color_id);
     virtual rgb_raw_t getColorRGBraw();
     virtual void correctColor(rgb_raw_t *colorRGB, uint8_t *redCorrected, uint8_t *greenCorrected, uint8_t *blueCorrected);
 
 private:
-    void addColorMap(colorid_t color_id, std::string color_name);
+    void addColorMap(uint8_t color_id, std::string color_name);
     double getHue(uint8_t red, uint8_t green, uint8_t blue);
 
     //! 色情報
-    std::map<colorid_t, std::string>    COLOR_NAME_MAP;
+    std::map<uint8_t, std::string>  COLOR_NAME_MAP;
 
     //! カラーセンサーのポート
     sensor_port_t   port;


### PR DESCRIPTION
# 関連Issue : Must

close #953 
close #952 
# 目的 : Must

色が変わった時に、振る舞いを変えられるようにする
# 実績
## やった事
### 概要 : Must
- 色の値の型を`colorid_t`から`uint8_t`に変更した
- 前回の色を記憶するようにした
- 色が変わった時には、ログに出力するようにした
### 確認した事 : Must
- プロジェクトのルートで、[よく使うスクリプト](../wiki/suteki_script)の`ファイルと結果のディレクトリの一覧を表示する`スクリプトを実行して、エラーが無い(**Must**)
  - [x] appビルドが成功した
  - [x] imgビルドが成功した
- [ ] UnitTestを実行して、エラーが無い
- 走行体の確認
  - [ ] 起動した
  - [ ] 起動通りの動作だった
### 考慮した事
#### [リスク](https://kotobank.jp/word/%E3%83%AA%E3%82%B9%E3%82%AF-183705)

なし
#### [懸念事項](https://kotobank.jp/word/%E6%87%B8%E5%BF%B5-490895)

なし
# 確認してほしい事
## ソースコード : Must

(やった事の内、ソースコードレベルで何を変更したかを記載する)
### 確認内容

該当する項目にチェックを付ける事
- プロジェクトのルートで、[よく使うスクリプト](../wiki/suteki_script)の`ファイルと結果のディレクトリの一覧を表示する`スクリプトを実行して、エラーが無い事
  - [x] appビルドが成功する事
  - [x] imgビルドが成功する事
- [x] 走行体のプログラムを変えた : 動作確認必要
  - [ ] タスクを増やした
  - [ ] 生成のタイミングを変更した
#### 動作確認が必要な場合に記載する

(どのような確認をおこなえば良いか(簡単な動作確認(起動、走行など)なのか、変更に特化した確認なのか)を記載する。)

---
# 確認結果

指摘がある場合は、コメントを残す事(参照 : [About pull request reviews - User Documentation](https://help.github.com/articles/about-pull-request-reviews/))
# 終了条件

以下が確認できた時に、本Pull requestをマージし、終了する。
- Merge先が`hackev/cpp/develop`ブランチである事
- 1人以上がソースコードを確認し、問題ない事
- 期待通りの動作である事
- MUST対応の指摘が無い事
