### PR TITLE
[レビュー]#974 : UnitTestを実行できるように修正した

### DIFF
--- a/hrp2/sdk/workspace/hackEV/params/CourseInformation.h
+++ b/hrp2/sdk/workspace/hackEV/params/CourseInformation.h
@@ -4,7 +4,7 @@
  */
 #pragma once
 
-#include "ev3api.h"
+#include "product.h"
 #include "EV3Position.h"
 #include <vector>
 


### PR DESCRIPTION
# 関連Issue : Must
closes #974 

# 目的 : Must
テストを実行可能にする

# 実績
## やった事
### 概要 : Must
モデル固有情報が格納された`ev3api.h`を直接#includeしていた。
UnitTestではモデル固有情報を参照せず、ロジックのみをテストしていた為に、実行できなくなっていた。

#includeするファイルを`ev3api.h`から`product.h`に変更した。
その結果、モデル固有情報を参照する必要がない場合には、`ev3api.h`を#include

### 確認した事 : Must
* プロジェクトのルートで、[よく使うスクリプト](../wiki/suteki_script)の`ファイルと結果のディレクトリの一覧を表示する`スクリプトを実行して、エラーが無い(**Must**)
  - [x] appビルドが成功した
  - [x] imgビルドが成功した
- [x] UnitTestを実行して、エラーが無い
* 走行体の確認
  - [ ] 起動した
  - [ ] 起動通りの動作だった

# 終了条件
テストを実行できるようになり、`product.h`は他のファイルでも実施している方法の為、セルフマージします

* Merge先が`hackev/cpp/develop`ブランチである事
* 1人以上がソースコードを確認し、問題ない事
* 期待通りの動作である事
* MUST対応の指摘が無い事
